### PR TITLE
[ENH] update ConFixel shasum in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM pennlinc/modelarray_build:0.0.1
 ## Versions and parameters:
 # specify the commit SHA:  # e.g. https://github.com/PennLINC/qsiprep/blob/master/Dockerfile#L174
     # should be the full SHA
-ENV commitSHA_confixel="b696debbe52982ab8b6e69e03bfb58f94c6bf4c5"
+ENV commitSHA_confixel="4c5def285b01836a15d0ac0dd049be0a3389b762"
 
 
 ## Install ConFixel (python package)


### PR DESCRIPTION
This PR updated ConFixel shasum to be included in the ModelArray-ConFixel docker image. ConFixel shasum was changed from `b696deb` (Mar 13, 2023) to `4c5def2` (Dec 15, 2023).

During this time, several enhancements/fixes were made in ConFixel, including:
- [added ConCIFTI](https://github.com/PennLINC/ConFixel/commit/1bea7ec10e8af6c6f81792edb6761fd4fce424c2)
- [fixed issue of deprecated get_data()](https://github.com/PennLINC/ConFixel/commit/55cdc82f93d3c8c04ab7b3b9b81a9d4cf6792424)
- [updated contact information](https://github.com/PennLINC/ConFixel/commit/8f3c32751e9faeae55c83ce662833711f7bcd5eb)